### PR TITLE
Fix loading error due to a quote in Python 3.10

### DIFF
--- a/src/endstone_primebds/commands/Server/rank.py
+++ b/src/endstone_primebds/commands/Server/rank.py
@@ -150,8 +150,8 @@ def handler(self: "PrimeBDS", sender: CommandSender, args: list[str]) -> bool:
         sender.send_message(f"§bRank: §r{proper_rank}")
         sender.send_message(f"§bWeight: §r{rank.get('weight', 0)}")
         sender.send_message(f"§bInherits: §r{rank.get('inherits', [])}")
-        sender.send_message(f"§bPrefix: §r{rank.get('prefix', "Unset")}")
-        sender.send_message(f"§bSuffix: §r{rank.get('suffix', "Unset")}")
+        sender.send_message(f"§bPrefix: §r{rank.get('prefix', 'Unset')}")
+        sender.send_message(f"§bSuffix: §r{rank.get('suffix', 'Unset')}")
         sender.send_message("§bPermissions:")
         for perm, value in rank.get("permissions", {}).items():
             color = "§a" if value else "§c"


### PR DESCRIPTION

Logs:
```
[21:37:35 ERROR]: Error occurred when trying to load plugin from entry point 'primebds':
[21:37:35 ERROR]: Traceback (most recent call last):
[21:37:35 ERROR]:   File "/home/container/python/lib/python3.10/site-packages/endstone/plugin/plugin_loader.py", line 190, in _load_plugin_from_ep
[21:37:35 ERROR]:     cls = ep.load()
[21:37:35 ERROR]:   File "/home/container/python/lib/python3.10/site-packages/importlib_metadata/__init__.py", line 226, in load
[21:37:35 ERROR]:     module = import_module(self.module)
[21:37:35 ERROR]:   File "/home/container/python/lib/python3.10/importlib/__init__.py", line 126, in import_module
[21:37:35 ERROR]:     return _bootstrap._gcd_import(name[level:], package, level)
[21:37:35 ERROR]:   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
[21:37:35 ERROR]:   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
[21:37:35 ERROR]:   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
[21:37:35 ERROR]:   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
[21:37:35 ERROR]:   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
[21:37:35 ERROR]:   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
[21:37:35 ERROR]:   File "/home/container/bedrock_server/plugins/.local/lib/python3.10/site-packages/endstone_primebds/__init__.py", line 1, in <module>
[21:37:35 ERROR]:     from endstone_primebds.primebds import PrimeBDS
[21:37:35 ERROR]:   File "/home/container/bedrock_server/plugins/.local/lib/python3.10/site-packages/endstone_primebds/primebds.py", line 10, in <module>
[21:37:35 ERROR]:     from endstone_primebds.commands import (
[21:37:35 ERROR]:   File "/home/container/bedrock_server/plugins/.local/lib/python3.10/site-packages/endstone_primebds/commands/__init__.py", line 230, in <module>
[21:37:35 ERROR]:     preload_commands()
[21:37:35 ERROR]:   File "/home/container/bedrock_server/plugins/.local/lib/python3.10/site-packages/endstone_primebds/commands/__init__.py", line 179, in preload_commands
[21:37:35 ERROR]:     module = importlib.import_module(module_import_path)
[21:37:35 ERROR]:   File "/home/container/python/lib/python3.10/importlib/__init__.py", line 126, in import_module
[21:37:35 ERROR]:     return _bootstrap._gcd_import(name[level:], package, level)
[21:37:35 ERROR]:   File "/home/container/bedrock_server/plugins/.local/lib/python3.10/site-packages/endstone_primebds/commands/Server/rank.py", line 153
[21:37:35 ERROR]:     sender.send_message(f"Prefix: {rank.get('prefix', "Unset")}")
[21:37:35 ERROR]:                                                              ^^^^^
[21:37:35 ERROR]: SyntaxError: f-string: unmatched '('
[21:37:35 ERROR]: 
```
