### PR TITLE
docs: change link to Endstone's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hello!
 This is PrimeBDS, an essentials plugin for diagnostics, stability, and quality of life on Minecraft Bedrock Edition.
-This plugin runs on the Endstone plugin loader: https://endstone.readthedocs.io/en/latest/
+This plugin runs on the Endstone plugin loader: https://endstone.dev/latest/
 
 # Features
 The full documentation can be found on the [wiki](https://github.com/PrimeStrat/primebds/wiki)


### PR DESCRIPTION
I don't believe the documentation on Read The Docs is current anymore. I don't see the [FAQ](https://endstone.dev/latest/getting-started/faq/) section there.

This PR changes the link in `README.md` to https://endstone.dev/latest/ instead.